### PR TITLE
Support ruleset hot reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 .idea/misc.xml
+
+# MacOS
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.schwarzit'
-version '1.0.4'
+version '1.0.5'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/schwarzit/spectralIntellijPlugin/FileListener.java
+++ b/src/main/java/com/schwarzit/spectralIntellijPlugin/FileListener.java
@@ -1,0 +1,46 @@
+package com.schwarzit.spectralIntellijPlugin;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.AsyncFileListener;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.schwarzit.spectralIntellijPlugin.exceptions.ProjectSettingsException;
+import com.schwarzit.spectralIntellijPlugin.settings.ProjectSettingsState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public class FileListener implements AsyncFileListener {
+    @Override
+    public @Nullable ChangeApplier prepareChange(@NotNull List<? extends VFileEvent> events) {
+        try {
+            ProjectSettingsState storageManager = ProjectSettingsState.getInstance();
+            // Hot reloading of changes to the ruleset only works for local rule sets
+            if (storageManager.getRuleset().startsWith("http")) return null;
+
+            ProjectManager projectManager = ProjectManager.getInstanceIfCreated();
+            if (projectManager == null) return null;
+
+            Project project = projectManager.getDefaultProject();
+            VirtualFile[] contentRoots = ProjectRootManager.getInstance(project).getContentRoots();
+
+            events.stream()
+                    .filter(event -> {
+                        VirtualFile file = event.getFile();
+                        if (file == null) return false;
+                        return event.getFile().toNioPath().toAbsolutePath().equals(Path.of(storageManager.getRuleset()).toAbsolutePath());
+                    })
+                    .findFirst()
+                    .ifPresent(event -> VfsUtil.markDirtyAndRefresh(true, true, true, contentRoots));
+        } catch (ProjectSettingsException e) {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,8 @@
 
         <notificationGroup id="Spectral" displayType="BALLOON" icon="SpectralIcons.SpectralLogo"/>
         <errorHandler implementation="com.schwarzit.spectralIntellijPlugin.util.ErrorReportSubmitter"/>
+
+        <vfs.asyncListener implementation="com.schwarzit.spectralIntellijPlugin.FileListener"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,11 @@
 
     <change-notes><![CDATA[
         <ul>
+            <li><b>1.0.5</b> (2022-04-04)
+                <ul>
+                    <li>Added hot reloading for local rule-sets</li>
+                </ul>
+            </li>
             <li><b>1.0.4</b> (2022-04-04)
                 <ul>
                     <li>Added support for linting OpenAPI specs referencing other files e.g. DTOs using a relative path</li>

--- a/src/test/java/com/schwarzit/spectralIntellijPlugin/FileListenerTest.java
+++ b/src/test/java/com/schwarzit/spectralIntellijPlugin/FileListenerTest.java
@@ -1,0 +1,131 @@
+package com.schwarzit.spectralIntellijPlugin;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.schwarzit.spectralIntellijPlugin.exceptions.ProjectSettingsException;
+import com.schwarzit.spectralIntellijPlugin.settings.ProjectSettingsState;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class FileListenerTest {
+
+    @Test
+    void prepareChangeTest() {
+        try (MockedStatic<ProjectSettingsState> projectSettingsStateMockedStatic = mockStatic(ProjectSettingsState.class)) {
+            ProjectSettingsState projectSettingsStateMock = mock(ProjectSettingsState.class);
+            projectSettingsStateMockedStatic.when(ProjectSettingsState::getInstance).thenReturn(projectSettingsStateMock);
+
+            try (MockedStatic<ProjectManager> projectManagerMockedStatic = mockStatic(ProjectManager.class)) {
+                ProjectManager projectManagerMock = mock(ProjectManager.class);
+                projectManagerMockedStatic.when(ProjectManager::getInstanceIfCreated).thenReturn(projectManagerMock);
+
+                when(projectManagerMock.getDefaultProject()).thenReturn(mock(Project.class));
+
+                try (MockedStatic<ProjectRootManager> projectRootManagerMockedStatic = mockStatic(ProjectRootManager.class)) {
+                    ProjectRootManager projectRootManagerMock = mock(ProjectRootManager.class);
+                    projectRootManagerMockedStatic.when(() -> ProjectRootManager.getInstance(any())).thenReturn(projectRootManagerMock);
+
+                    VirtualFile[] virtualFiles = new VirtualFile[0];
+                    when(projectRootManagerMock.getContentRoots()).thenReturn(virtualFiles);
+
+                    try (MockedStatic<VfsUtil> vfsUtilMockedStatic = mockStatic(VfsUtil.class)) {
+                        VFileEvent vFileEventMock = mock(VFileEvent.class);
+                        VirtualFile virtualFileMock = mock(VirtualFile.class);
+                        when(vFileEventMock.getFile()).thenReturn(virtualFileMock);
+                        when(virtualFileMock.toNioPath()).thenReturn(Path.of("/TestPath"));
+                        when(projectSettingsStateMock.getRuleset()).thenReturn("/TestPath");
+
+                        //noinspection ResultOfMethodCallIgnored
+                        new FileListener().prepareChange(List.of(vFileEventMock));
+
+                        vfsUtilMockedStatic.verify(() -> VfsUtil.markDirtyAndRefresh(true, true, true, virtualFiles));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void prepareChangeWithoutMatchingFileTest() {
+        try (MockedStatic<ProjectSettingsState> projectSettingsStateMockedStatic = mockStatic(ProjectSettingsState.class)) {
+            ProjectSettingsState projectSettingsStateMock = mock(ProjectSettingsState.class);
+            projectSettingsStateMockedStatic.when(ProjectSettingsState::getInstance).thenReturn(projectSettingsStateMock);
+
+            try (MockedStatic<ProjectManager> projectManagerMockedStatic = mockStatic(ProjectManager.class)) {
+                ProjectManager projectManagerMock = mock(ProjectManager.class);
+                projectManagerMockedStatic.when(ProjectManager::getInstanceIfCreated).thenReturn(projectManagerMock);
+
+                when(projectManagerMock.getDefaultProject()).thenReturn(mock(Project.class));
+
+                try (MockedStatic<ProjectRootManager> projectRootManagerMockedStatic = mockStatic(ProjectRootManager.class)) {
+                    ProjectRootManager projectRootManagerMock = mock(ProjectRootManager.class);
+                    projectRootManagerMockedStatic.when(() -> ProjectRootManager.getInstance(any())).thenReturn(projectRootManagerMock);
+
+                    VirtualFile[] virtualFiles = new VirtualFile[0];
+                    when(projectRootManagerMock.getContentRoots()).thenReturn(virtualFiles);
+
+                    try (MockedStatic<VfsUtil> vfsUtilMockedStatic = mockStatic(VfsUtil.class)) {
+                        VFileEvent vFileEventMock = mock(VFileEvent.class);
+                        VirtualFile virtualFileMock = mock(VirtualFile.class);
+                        when(vFileEventMock.getFile()).thenReturn(virtualFileMock);
+                        when(virtualFileMock.toNioPath()).thenReturn(Path.of("/DifferentTestPath"));
+                        when(projectSettingsStateMock.getRuleset()).thenReturn("/TestPath");
+
+                        //noinspection ResultOfMethodCallIgnored
+                        new FileListener().prepareChange(List.of(vFileEventMock));
+
+                        vfsUtilMockedStatic.verifyNoInteractions();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void prepareChangeWithUrlTest() {
+        try (MockedStatic<ProjectSettingsState> projectSettingsStateMockedStatic = mockStatic(ProjectSettingsState.class)) {
+            ProjectSettingsState projectSettingsStateMock = mock(ProjectSettingsState.class);
+            projectSettingsStateMockedStatic.when(ProjectSettingsState::getInstance).thenReturn(projectSettingsStateMock);
+
+            try (MockedStatic<VfsUtil> vfsUtilMockedStatic = mockStatic(VfsUtil.class)) {
+                VFileEvent vFileEventMock = mock(VFileEvent.class);
+                VirtualFile virtualFileMock = mock(VirtualFile.class);
+                when(vFileEventMock.getFile()).thenReturn(virtualFileMock);
+                when(virtualFileMock.toNioPath()).thenReturn(Path.of("/TestPath"));
+                when(projectSettingsStateMock.getRuleset()).thenReturn("https://some.url/ruleset");
+
+                //noinspection ResultOfMethodCallIgnored
+                new FileListener().prepareChange(List.of(vFileEventMock));
+
+                vfsUtilMockedStatic.verifyNoInteractions();
+            }
+        }
+    }
+
+    @Test
+    void prepareChangeWithExceptionTest() {
+        try (MockedStatic<ProjectSettingsState> projectSettingsStateMockedStatic = mockStatic(ProjectSettingsState.class)) {
+            projectSettingsStateMockedStatic.when(ProjectSettingsState::getInstance).thenThrow(new ProjectSettingsException("Error"));
+
+            try (MockedStatic<VfsUtil> vfsUtilMockedStatic = mockStatic(VfsUtil.class)) {
+                VFileEvent vFileEventMock = mock(VFileEvent.class);
+                VirtualFile virtualFileMock = mock(VirtualFile.class);
+                when(vFileEventMock.getFile()).thenReturn(virtualFileMock);
+                when(virtualFileMock.toNioPath()).thenReturn(Path.of("/DifferentTestPath"));
+                //noinspection ResultOfMethodCallIgnored
+                new FileListener().prepareChange(List.of(vFileEventMock));
+
+                vfsUtilMockedStatic.verifyNoInteractions();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10 

- Added an asynchronous file watcher to detect changes to the (local) ruleset and re-linting the open files if it was changed