### PR TITLE
Small improvements and support for absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 ## [Unreleased]
 
-## [2.1.0] - 2023-08-02
 
 ### Changed
 - Make compatible with IntelliJ IDEA 2023.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2023-08-02
+
+### Changed
+- Make compatible with IntelliJ IDEA 2023.2
+- Add support for absolute paths in file-matcher
+- Fixes & improvements to `README.md`
+- Add name of file being analysed to transient status message
+- Log an error if `spectral` execution fails due to misconfiguration. This is not ideal but at least offers some user feedback.
+
 ## [2.0.0] - 2023-07-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# jetbrains-plugin-template
+# Spectral Linter Plugin for JetBrains
 
-![Build](https://github.com/markbrockhoff/jetbrains-plugin-template/workflows/Build/badge.svg)
+![Build](https://github.com/SchwarzIT/spectral-intellij-plugin/workflows/Build/badge.svg)
 [![Version](https://img.shields.io/jetbrains/plugin/v/com.schwarzit.spectral-intellij-plugin.svg)](https://plugins.jetbrains.com/plugin/com.schwarzit.spectral-intellij-plugin)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.schwarzit.spectral-intellij-plugin.svg)](https://plugins.jetbrains.com/plugin/com.schwarzit.spectral-intellij-plugin)
 
@@ -17,7 +17,7 @@ OpenApi schemas.
 
 - Manually:
 
-  Download the [latest release](https://github.com/markbrockhoff/jetbrains-plugin-template/releases/latest) and install
+  Download the [latest release](https://github.com/SchwarzIT/spectral-intellij-plugin/releases/latest) and install
   it manually using
   <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>⚙️</kbd> > <kbd>Install plugin from disk...</kbd>
 
@@ -33,29 +33,36 @@ _Note: The CLI needs to be in your path and executable from the command line._
 
 Automatic linting of your OpenApi specifications and highlighting in your editor
 
-### Customizable Ruleset
+### Configurable Ruleset
 
 Specify your own [ruleset](https://meta.stoplight.io/docs/spectral/ZG9jOjYyMDc0NA-rulesets) in the plugins
 settings, under Preferences -> Tools -> Spectral -> Ruleset.
+
 There you can specify a file on your local machine or just paste the URL of a ruleset available on the internet
 e.g.: [Schwarz IT API linting rules](https://github.com/SchwarzIT/api-linter-rules).
 
 Examples:
 
-- Link to a hosted ruleset: https://raw.githubusercontent.com/SchwarzIT/api-linter-rules/main/spectral-api.yml
-- Local ruleset inside the project: ".spectral.json"
+- Link to a hosted ruleset: `https://raw.githubusercontent.com/SchwarzIT/api-linter-rules/main/spectral-api.yml`
+- Local ruleset relative to Project base-path: `.spectral.json`
+- Fully-qualified path: `/Users/mick/.spectral.yaml`
 
-### Customizable file matching
+### Configurable Included path patterns
 
-Select the files that will be linted. By default, every file called "openapi.json" or "openapi.yml" will be linted by
-the plugin when it's opened.
-You can adjust this in the settings under Preferences -> Tools -> Spectral -> Included files. All paths are relative
-to the projects working directory.
+Select the files that will be linted. By default, every file called "openapi.json", "openapi.yml" or "openapi.yaml"
+within the Project root will be matched for linting by the plugin when it's opened.
+
+You can adjust this in the settings under Preferences -> Tools -> Spectral -> Included path patterns. All paths are relative
+to the project's root directory unless absolute.
 
 Examples:
 
-- openapi.json: Matches the file called "openapi.json" inside the root directory of the project
-- components/**.json: Matches all files inside the directory "components" that end with ".json"
+- `openapi.json`: Matches the file called "openapi.json" inside the root directory of the project
+- `components/**.yaml`: Matches all files inside the subdirectory "components" that end with ".json"
+- `/Users/mick/code/**/openapi*.yaml`: Matches all YAML files within the absolute path "/Users/mick/code" that start with "openapi" 
+
+**Note:** Each file must also be recognised by the IDE as a JSON or YAML file - that is with a suitable File Type association.
+If it is detected as a plain text (or any other type) it will be ignored.
 
 <!-- Plugin description end -->
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ to the project's root directory unless absolute.
 Examples:
 
 - `openapi.json`: Matches the file called "openapi.json" inside the root directory of the project
-- `components/**.yaml`: Matches all files inside the subdirectory "components" that end with ".json"
-- `/Users/mick/code/**/openapi*.yaml`: Matches all YAML files within the absolute path "/Users/mick/code" that start with "openapi" 
+- `components/**.yaml`: Matches all files inside the project subdirectory "components" that end with ".yaml"
+- `/Users/mick/code/**/openapi*.yaml`: Matches all YAML files within the absolute path "/Users/mick/code" that start with "openapi" and end with ".yaml"
 
 **Note:** Each file must also be recognised by the IDE as a JSON or YAML file - that is with a suitable File Type association.
 If it is detected as a plain text (or any other type) it will be ignored.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.schwarzit.spectral-intellij-plugin
 pluginName=Spectral
 pluginRepositoryUrl=https://github.com/SchwarzIT/spectral-intellij-plugin
 # SemVer format -> https://semver.org
-pluginVersion=2.0.0
+pluginVersion=2.1.0
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=222
 #pluginUntilBuild=231.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ pluginRepositoryUrl=https://github.com/SchwarzIT/spectral-intellij-plugin
 pluginVersion=2.0.0
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=222
-pluginUntilBuild=231.*
+#pluginUntilBuild=231.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
 platformVersion=2022.2

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotator.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotator.kt
@@ -57,7 +57,7 @@ class SpectralExternalAnnotator : ExternalAnnotator<Pair<PsiFile,Editor>, List<S
         val computable = Computable { lintFile(info.second) }
         val indicator = BackgroundableProcessIndicator(
             info.second.project,
-            "Spectral: analyzing OpenAPI specification ${info.first.name} ...",
+            "Spectral: analyzing OpenAPI specification '${info.first.name}' ...",
             "Stop",
             "Stop file analysis",
             false
@@ -79,7 +79,7 @@ class SpectralExternalAnnotator : ExternalAnnotator<Pair<PsiFile,Editor>, List<S
             val issues = linter.run(editor.document.text)
             issues
         } catch (e: Throwable) {
-            logger.warn("Error running spectral command-line: $e", e)
+            logger.error(e)
             emptyList()
         }
     }

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotator.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotator.kt
@@ -43,7 +43,7 @@ class SpectralExternalAnnotator : ExternalAnnotator<Pair<PsiFile,Editor>, List<S
         val iterator = includedFiles.iterator()
         while (iterator.hasNext()) {
             val pathPattern = iterator.next()
-            if (! Paths.get(pathPattern).isAbsolute()) matcherPattern += file.project.basePath + "/"
+            if (!Paths.get(pathPattern).isAbsolute) matcherPattern += file.project.basePath + "/"
             matcherPattern += pathPattern
             matcherPattern += if (iterator.hasNext()) "," else "}"
         }

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsState.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsState.kt
@@ -15,6 +15,7 @@ class ProjectSettingsState : PersistentStateComponent<ProjectSettingsState> {
     var includedFiles: String = """
         **openapi.json
         **openapi.yml
+        **openapi.yaml
     """.trimIndent()
 
     override fun getState(): ProjectSettingsState {

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/SettingsComponent.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/SettingsComponent.kt
@@ -16,7 +16,7 @@ class SettingsComponent {
         mainPanel =
             FormBuilder.createFormBuilder()
                 .addLabeledComponent(JBLabel("Ruleset"), rulesetInput)
-                .addLabeledComponent(JBLabel("Included files"), includedFilesInput)
+                .addLabeledComponent(JBLabel("Included path patterns"), includedFilesInput)
                 .addComponentFillVertically(JPanel(), 0)
                 .panel
     }


### PR DESCRIPTION
- Removed pluginUntilBuild from gradle.properties to allow plugin to work in newer JetBrains IDEs (including IDEA 2023.2).
- Added '**openapi.yaml' to default list of included files
- Fixed broken some URLs in README.md
- improved some README.md formatting and included details on using Absolute as well as relative paths for ruleset and included files. Added explanation that files *must also be detected as JSON/YAML* to be included.
- Changed field name for included path patterns in settings
- Improved SpectralExternalAnnotator.kt isFileIncluded() to also support absolute paths.
- Modified collectInformation and doAnnotate to also pass the PsiFile so that activity message van include the filename.
- Made failure to successfully run lintFile() log a warning message rather than debug so that user can see something in the IDE logs. Otherwise it fails silently.