### PR TITLE
refactor!: Refactor file matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## [Unreleased]
 
+### Added
+- Improve check for files to lint on non unix operating systems
+
 ### Changed
 - [BREAKING] Use [ant pattern matching](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html) to check for included files. This might be a breaking change for some people, please check your included files in the settings if you encounter any issues. E.g. the default inclusion pattern `**openapi.json` would now no longer match the path `openapi/v1-openapi.json`, please use `**/*openapi.json` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## [Unreleased]
 
+### Changed
+- [BREAKING] Use [ant pattern matching](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html) to check for included files. This might be a breaking change for some people, please check your included files in the settings if you encounter any issues. E.g. the default inclusion pattern `**openapi.json` would now no longer match the path `openapi/v1-openapi.json`, please use `**/*openapi.json` instead.
+
 ## [2.1.3] - 2023-09-01
 
 ### Changed
@@ -68,8 +71,7 @@
 - BREAKING: Spectral no longer comes bundled with the plugin and needs to be installed additionally now
 - BREAKING: Settings now only apply on a project level
 
-[Unreleased]: https://github.com/SchwarzIT/spectral-intellij-plugin/compare/v2.1.3...HEAD
-[2.1.3]: https://github.com/SchwarzIT/spectral-intellij-plugin/compare/v2.1.2...v2.1.3
+[Unreleased]: https://github.com/SchwarzIT/spectral-intellij-plugin/compare/v2.1.2...HEAD
 [2.1.2]: https://github.com/SchwarzIT/spectral-intellij-plugin/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/SchwarzIT/spectral-intellij-plugin/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/SchwarzIT/spectral-intellij-plugin/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -45,23 +45,25 @@ Examples:
 
 - Link to a hosted ruleset: `https://raw.githubusercontent.com/SchwarzIT/api-linter-rules/main/spectral-api.yml`
 - Local ruleset relative to Project base-path: `.spectral.json`
-- Fully-qualified path: `/Users/mick/.spectral.yaml`
+- Fully-qualified path: `/Users/user/.spectral.yaml`
 
 ### Configurable Included path patterns
 
 Select the files that will be linted. By default, every file called "openapi.json", "openapi.yml" or "openapi.yaml"
 within the Project root will be matched for linting by the plugin when it's opened.
 
-You can adjust this in the settings under Preferences -> Tools -> Spectral -> Included path patterns. All paths are relative
-to the project's root directory unless absolute.
+You can adjust this in the settings under Preferences -> Tools -> Spectral -> Included path patterns. All paths are
+relative to the project's root directory unless absolute.
 
 Examples:
 
 - `openapi.json`: Matches the file called "openapi.json" inside the root directory of the project
-- `components/**.yaml`: Matches all files inside the project subdirectory "components" that end with ".yaml"
-- `/Users/mick/code/**/openapi*.yaml`: Matches all YAML files within the absolute path "/Users/mick/code" that start with "openapi" and end with ".yaml"
+- `components/**/*.yaml`: Matches all files inside the project subdirectory "components" that end with ".yaml"
+- `/Users/user/code/**/openapi*.yaml`: Matches all YAML files within the absolute path "/Users/mick/code" that start
+  with "openapi" and end with ".yaml"
 
-**Note:** Each file must also be recognised by the IDE as a JSON or YAML file - that is with a suitable File Type association.
+**Note:** Each file must also be recognised by the IDE as a JSON or YAML file - that is with a suitable File Type
+association.
 If it is detected as a plain text (or any other type) it will be ignored.
 
 <!-- Plugin description end -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,5 +141,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.10")
+    implementation("org.springframework:spring-core:6.0.11")
+
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.schwarzit.spectral-intellij-plugin
 pluginName=Spectral
 pluginRepositoryUrl=https://github.com/SchwarzIT/spectral-intellij-plugin
 # SemVer format -> https://semver.org
-pluginVersion=2.1.3
+pluginVersion=3.0.0
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=222
 #pluginUntilBuild=231.*

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsState.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/settings/ProjectSettingsState.kt
@@ -15,9 +15,9 @@ class ProjectSettingsState : PersistentStateComponent<ProjectSettingsState> {
 
     var ruleset: String = "https://raw.githubusercontent.com/SchwarzIT/api-linter-rules/main/spectral-api.yml"
     var includedFiles: String = """
-        **openapi.json
-        **openapi.yml
-        **openapi.yaml
+        **/*openapi.json
+        **/*openapi.yml
+        **/*openapi.yaml
     """.trimIndent()
 
     override fun getState(): ProjectSettingsState {

--- a/src/test/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotatorTest.kt
+++ b/src/test/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralExternalAnnotatorTest.kt
@@ -11,9 +11,16 @@ class SpectralExternalAnnotatorTest {
 
     @ParameterizedTest(name = "isFileIncluded {index} - {arguments}")
     @MethodSource("provideIsFileIncludedTestParams")
-    fun isFileIncluded(basePath: String, path: String, includedFiles: List<String>, isIncluded: Boolean) {
+    fun isFileIncluded(
+        basePath: String,
+        path: String,
+        includedFiles: List<String>,
+        isIncluded: Boolean,
+        separator: String
+    ) {
         val spectralExternalAnnotator = SpectralExternalAnnotator()
-        val fileIncluded = spectralExternalAnnotator.isFileIncluded(basePath, Paths.get(path), includedFiles)
+        val fileIncluded =
+            spectralExternalAnnotator.isFileIncluded(Paths.get(basePath), Paths.get(path), includedFiles, separator)
         Assertions.assertEquals(fileIncluded, isIncluded)
     }
 
@@ -24,9 +31,21 @@ class SpectralExternalAnnotatorTest {
                 Arguments.of(
                     "/home/user/project",
                     "/home/user/project/src/openapi.json",
-                    listOf("**openapi.json"),
-                    true
-                )
+                    listOf("**/openapi.json"),
+                    true,
+                    "/"
+                ),
+                Arguments.of(
+                    "C:\\Users\\Username\\Projekt\\",
+                    "C:\\Users\\Username\\Projekt\\API_Name.yaml",
+                    listOf("**.yaml"),
+                    true,
+                    "\\"
+                ),
+                Arguments.of("/test", "/test/testing.test", listOf("*.test"), true, "/"),
+                Arguments.of("/", "/foo/bar/something/test.json", listOf("**/*.json"), true, "/"),
+                Arguments.of("/", "test.test", listOf("*.json", "*.yml"), false, "/"),
+                Arguments.of("/", "/test/openapi.json", listOf("**.json"), false, "/")
             )
         }
     }


### PR DESCRIPTION
[BREAKING]
Use [ant pattern matching](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html) to check for included files.
This might be a breaking change for some people, please check your included files in the settings if you encounter any issues.
E.g. the default inclusion pattern `**openapi.json` would now no longer match the path `openapi/v1-openapi.json`, please use `**/*openapi.json` instead.