### PR TITLE
github-121: fix - spectral starter command on windows.

### DIFF
--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
@@ -10,6 +10,7 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.text.ParseException
 import java.time.Duration
+import java.util.Locale
 import java.util.concurrent.ExecutionException
 
 @Service(Service.Level.PROJECT)
@@ -47,7 +48,9 @@ class SpectralRunner(private val project: Project) {
     }
 
     private fun createCommand(): GeneralCommandLine {
-        return GeneralCommandLine("spectral").withCharset(StandardCharsets.UTF_8)
+        val isWindows = System.getProperty("os.name", "unknown").lowercase(Locale.US).contains("windows")
+        val command = if (isWindows) listOf("cmd", "/C", "spectral.cmd") else listOf("spectral")
+        return GeneralCommandLine(command).withCharset(StandardCharsets.UTF_8)
     }
 
     @Throws(SpectralException::class)


### PR DESCRIPTION
This fixes #121 when the plugin fails to start `spectral` process on Windows.

Basically, the issue lies within how Windows handles the launch of the shell scripts. If you want to execute the shell script, which `spectral.cmd` (the executable file name on Windows) effectively is, then in fact you get to start the shell (CMD) and make it run the script.

This is different from Unix where "create process" works if you directly pass in the shell script name. 