### PR TITLE
Fix linter failure on newer Node versions due to punycode deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Make com.intellij.modules.json an explicit dependency to resolve plugin validation issue
+- Fix an issue with deprecation warnings logged to the spectral commands output for Node versions >=21
 
 ## [3.0.1] - 2023-10-20
 

--- a/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
+++ b/src/main/kotlin/com/schwarzit/spectralIntellijPlugin/SpectralRunner.kt
@@ -47,7 +47,9 @@ class SpectralRunner(private val project: Project) {
     }
 
     private fun createCommand(): GeneralCommandLine {
-        return GeneralCommandLine("spectral").withCharset(StandardCharsets.UTF_8)
+        // NODE_OPTIONS need to be set as the spectral cli currently uses a deprecated dependency (See: https://github.com/stoplightio/spectral/issues/2622)
+        // By default this warning would be printed when executing the command making the plugin fail when attempting to parse the command response
+        return GeneralCommandLine("spectral").withCharset(StandardCharsets.UTF_8).withEnvironment("NODE_OPTIONS", "--no-warnings")
     }
 
     @Throws(SpectralException::class)


### PR DESCRIPTION
When running the spectral cli on node versions >=21 a deprecation warning was printed to stdout. This warning interfered while trying to parse the spectral response.